### PR TITLE
Removed command tree re-sync on bot startup

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -43,7 +43,7 @@ async def on_ready():
     client.logger.info(connection)
 
     # Clear all commands
-    await clear_all_commands(client=client)
+    # await clear_all_commands(client=client)
 
     # Load cogs
     for path in Path("cogs").rglob("*.py"):
@@ -58,7 +58,7 @@ async def on_ready():
             client.logger.error(f"Failed to load {cog}: {e}")
 
     # Sync commands
-    await sync_all_commands(client=client)
+    # await sync_all_commands(client=client)
 
     # Set status
     await client.change_presence(


### PR DESCRIPTION
## 📌 Description

Bot restarting re-syncs the command tree. This is not necessary, not to mention the possibility of hitting rate limits (https://discord.com/developers/docs/interactions/application-commands#registering-a-command). If necessary, we can re-sync the commands as a one-time thing from our local env. This PR comments the re-syncing function calls.

---

## 🧱 Type of Change

- [ ] 🐛 Bug fix – Non-breaking fix for a functional/logic error
- [ ] ✨ New feature – Adds functionality without breaking existing commands or APIs
- [ ] ⚠️ Breaking change – Backward-incompatible change (commands, bot behavior, etc.)
- [ ] 📝 Documentation update – README, comments, help text, etc.
- [ ] 🧪 Test suite change – Adds/updates unit, integration, or manual tests
- [ ] ⚙️ CI/CD pipeline update – GitHub Actions, Docker, pre-commit, etc.
- [ ] 🧹 Refactor – Code cleanup, improvements, or style changes
- [x] 🐢 Performance improvement – Faster command responses or reduced resource use
- [ ] 🕵️ Logging/debugging – Improved diagnostics, logs, or debug output
- [ ] 🔧 Tooling – Scripts, benchmarks, or local dev improvements
- [ ] 🔒 Security fix – Permissions, validation, or Discord API-related vulnerabilities
- [ ] 🧰 Dependency update – Library or package updates

---

## 🧪 How Has This Been Tested?

- [ ] Unit Tests (`tests/unit/`)
- [ ] Integration Tests (`tests/integration/`)
- [ ] Manual testing in Discord
- [ ] CI / pre-commit run

> **Test Environment:**
> - OS: (e.g., `Linux`)
> - Python: (e.g., `3.12`)
> - Discord.py version: (e.g., `2.3.2`)
> - [ ] Docker build tested

---

## ✅ Checklist

- [ ] My code follows repo [CONTRIBUTING.md](https://github.com/pesu-dev/discord-bot/blob/main/.github/CONTRIBUTING.md) guidelines
- [ ] Self-review completed
- [ ] Added/updated comments and docstrings
- [ ] Updated relevant docs (README, help text, etc.)
- [ ] No new warnings or errors introduced
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Ran linting and formatting (`pre-commit run --all-files`)
- [ ] Docker image builds and runs
- [ ] Did not change `config.json` (unless with explicit permission)
- [ ] Changes are backwards compatible (if applicable)
- [ ] Feature flags or `.env` vars updated (if applicable)
- [ ] Tested in multiple environments (if applicable)

---

## 🛠️ Affected Bot Areas

- [ ] Commands (e.g., `/ping`, `/help`)
- [ ] Event handling (on_message, on_ready, etc.)
- [ ] Permissions/roles
- [ ] Database/Storage
- [x] Discord API/Integrations
- [x] Bot startup/shutdown
- [ ] CI / pre-commit
- [ ] Dockerfile / build
- [ ] Dependencies (`requirements.txt`)
- [ ] Tooling/scripts
- [ ] Other (specify in Additional Notes)

---

## 📸 Screenshots / Demos (if applicable)

---

## 🧠 Additional Notes
